### PR TITLE
Fix render with additional attributes (not defined at template)

### DIFF
--- a/lib/tox/renderer.rb
+++ b/lib/tox/renderer.rb
@@ -40,8 +40,8 @@ module Tox
         { t: :text, v: o }
       else
         o.map do |key, sub|
-          render_template(t[key], sub)
-        end
+          render_template(t[key], sub) if t[key]
+        end.compact
       end
     end
 

--- a/test/tox_test.rb
+++ b/test/tox_test.rb
@@ -393,6 +393,27 @@ class ToxTest < Minitest::Test
     end
   end
 
+  def test_render_with_additional_attributes
+    test_case_render(
+      %{
+        <name>
+          <first>Mike</first>
+          <last>Ross</last>
+        </name>
+      },
+      {
+        f:       'Mike',
+        l:       'Ross',
+        aliases: ''
+      }
+    ) do
+      el(:name, {
+        f: el(:first, text),
+        l: el(:last, text)
+      })
+    end
+  end
+
   def test_namespaces
     test_case(
       %{


### PR DESCRIPTION
`NoMethodError: undefined method '[]' for nil:NilClass` was raised in such situation