### PR TITLE
Do not use Struct

### DIFF
--- a/lib/tox/template.rb
+++ b/lib/tox/template.rb
@@ -77,7 +77,14 @@ module Tox
 
     # These are for matching actual XML Nodes ----------
 
-    class XMLNode < Struct.new(:name, :ns)
+    class XMLNode
+      attr_accessor :name, :ns
+
+      def initialize(name = nil, ns = nil)
+        @name = name
+        @ns   = ns
+      end
+
       def default
         nil
       end

--- a/test/template/element_test.rb
+++ b/test/template/element_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class TemplateElementTest < Minitest::Test
+  def test_differ
+    element_a = Tox::Template::Element.new(:name, :ns, { val: :a })
+    element_b = Tox::Template::Element.new(:name, :ns, { val: :b })
+
+    refute_equal element_a, element_b
+  end
+end


### PR DESCRIPTION
This fixes problems with comparison of Tox::Temaplate::Element objects.

Before:

    el_a = Tox::Template::Element.new(:name, :ns, { val: :a })
    el_b = Tox::Template::Element.new(:name, :ns, { val: :b })
    el_a == el_b

Now:

    el_a = Tox::Template::Element.new(:name, :ns, { val: :a })
    el_b = Tox::Template::Element.new(:name, :ns, { val: :b })
    el_a != el_b

This also increases performance a little.