### PR TITLE
Do not remove newlines

### DIFF
--- a/lib/tox/template.rb
+++ b/lib/tox/template.rb
@@ -56,7 +56,7 @@ module Tox
 
     def parse(xml)
       p = Parser.new(@template)
-      Ox.sax_parse(p, xml)
+      Ox.sax_parse(p, xml, skip: :skip_none)
       p.result
     end
 

--- a/test/tox_test.rb
+++ b/test/tox_test.rb
@@ -552,6 +552,19 @@ class ToxTest < Minitest::Test
     end
   end
 
+  def test_newlines
+    test_case(
+      %{
+        <description>Hello\nWorld</description>
+      },
+      {
+        description: "Hello\nWorld"
+      }
+    ) do
+      { description: el(:description, text) }
+    end
+  end
+
   def test_namespaces
     test_case(
       %{


### PR DESCRIPTION
Ox by default skips newlines since 2.5.0 version (https://github.com/ohler55/ox/blob/master/CHANGELOG.md#250---may-4-2017)