### PR TITLE
Fix restrict incompatible ox version

### DIFF
--- a/lib/tox/version.rb
+++ b/lib/tox/version.rb
@@ -1,3 +1,3 @@
 module Tox
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/tox.gemspec
+++ b/tox.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ox'
+  spec.add_dependency 'ox', '< 2.9.3'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/tox.gemspec
+++ b/tox.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ox', '< 2.9.3'
+  spec.add_dependency 'ox', '!= 2.9.3'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
After last update we got error in out test suite:

```
Finished in 0.003121s, 3204.1012 runs/s, 5126.5620 assertions/s.

  1) Failure:
ToxTest#test_simple_el_wrapped_empty [/Users/piotrwasiak/Prj/prograils/tox/test/tox_test.rb:680]:
Expected: ""
  Actual: "<name>你好世界</name>"
```

Content in this example is initially : 
```
%{
        <something/>
      },
```