### PR TITLE
CON-2543 Do not raise on invalid XML characters

### DIFF
--- a/lib/tox/template.rb
+++ b/lib/tox/template.rb
@@ -50,6 +50,11 @@ module Tox
       end
     end
 
+    OX_OPTIONS = {
+      effort: :tolerant, # do not raise on invalid characters,
+      invalid_replace: nil
+    }.freeze
+
     def initialize(template)
       @template = Element.new(nil, nil, DSL.compose(template))
     end
@@ -63,8 +68,8 @@ module Tox
     def render(o, pretty: false)
       r = Renderer.new(@template).render(o)
 
-      options = {}
-      options[:indent] = -1 if !pretty
+      options = OX_OPTIONS
+      options = options.merge(indent: -1) unless pretty
 
       r ? Ox.dump(r, options) : ''
     end

--- a/test/tox_test.rb
+++ b/test/tox_test.rb
@@ -76,6 +76,17 @@ class ToxTest < Minitest::Test
     end
   end
 
+  def test_invalid_xml_chars
+    test_case(
+      %{
+        <name>&#x0001;</name>
+      },
+      "\u0001"
+    ) do
+      el(:name, text)
+    end
+  end
+
   def test_io
     test_case_parse(
       StringIO.new(%{


### PR DESCRIPTION
Up to now `Ox::SyntaxError: '\#x01' is not a valid XML character.` error was raised.

Link: https://piesync.atlassian.net/browse/CON-2543